### PR TITLE
Removed go vet import

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,6 @@ if [[ $TEST_SUITE == "unit" ]]; then
 	go get github.com/axw/gocov/gocov
 	go get github.com/mattn/goveralls
 	go get -u github.com/golang/lint/golint
-	go get golang.org/x/tools/cmd/vet
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/smartystreets/goconvey/convey
 	go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Removed go vet import because of this [commit](https://github.com/golang/tools/commit/adaaa074861b0d254acf51dec74daf7c2ba20e90).