### PR TITLE
Fixes #14: Refactor plugin initialization to be able to use proc_path passed in from config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,41 @@ This builds the plugin in `/build/rootfs/`
 
 ### Configuration and Usage
 * Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
+* If /proc resides in a different directory, say for example by mounting host /proc inside a container at /hostproc, a proc_path configuration item can be added to snapd global config or as part of the task manifest for the metrics to be collected.
+
+As part of snapd global config
+
+```yaml
+---
+control:
+  plugins:
+    collector:
+      cpu:
+        all:
+          proc_path: /hostproc
+```
+
+Or as part of the task manifest
+
+```json
+{
+...
+    "workflow": {
+        "collect": {
+            "metrics": {
+	      "/intel/procfs/cpu/all/user_jiffies" : {}
+	    },
+	    "config": {
+	      "/intel/procfs": {
+                "proc_path": "/hostproc"
+	      }
+	    },
+	    ...
+       },
+    },
+...
+```
+
 * Load the plugin and create a task, see example in [Examples](https://github.com/intelsdi-x/snap-plugin-collector-cpu/blob/master/README.md#examples).
 
 ## Documentation

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/core/ctypes"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/suite"
 )
@@ -57,6 +58,8 @@ func TestGetStatsSuite(t *testing.T) {
 
 func mockNew() *Plugin {
 	p := New()
+	emptyCfg := make(map[string]ctypes.ConfigValue)
+	p.init(emptyCfg)
 	So(p, ShouldNotBeNil)
 	So(p.snapMetricsNames, ShouldNotBeNil)
 	return p

--- a/main.go
+++ b/main.go
@@ -29,10 +29,5 @@ import (
 )
 
 func main() {
-	cpuPlugin := cpu.New()
-	if cpuPlugin == nil {
-		panic("Failed to initialize plugin!\n")
-	}
-	meta := cpu.Meta()
-	plugin.Start(meta, cpuPlugin, os.Args[1])
+	plugin.Start(cpu.Meta(), cpu.New(), os.Args[1])
 }


### PR DESCRIPTION
Adds support for setting "proc_path" configuration item in snapd global config or config item for a metric namespace in a task manifest to be used over the default "/proc/stat". This is useful in a containerized environment where the host /proc may be mounted to a different directory inside the container.