### PR TITLE
Fix broken jenkins ci links in Snap

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -5,7 +5,5 @@ license: Apache-2.0
 description: "Collects Linux cpu metrics from /proc/stat."
 badge:
   - "[![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-collector-cpu.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-collector-cpu)"
-  - "[![Build Status](https://ci.snap-telemetry.io/buildStatus/icon?job=snap-plugin-collector-cpu-large-prb-k8s)](https://ci.snap-telemetry.io/job/snap-plugin-collector-cpu-large-prb-k8s/)"
 ci:
   - https://travis-ci.org/intelsdi-x/snap-plugin-collector-cpu
-  - https://ci.snap-telemetry.io/job/snap-plugin-collector-cpu-large-prb-k8s/


### PR DESCRIPTION
Remove reference to jenkins ci.