### PR TITLE
Adding large test to metadata

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -5,5 +5,7 @@ license: Apache-2.0
 description: "Collects Linux cpu metrics from /proc/stat."
 badge:
   - "[![Build Status](https://travis-ci.org/intelsdi-x/snap-plugin-collector-cpu.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap-plugin-collector-cpu)"
+  - "[![Build Status](https://ci.snap-telemetry.io/job/snap-plugin-collector-cpu-ec2-periodic/badge/icon)](https://ci.snap-telemetry.io/job/snap-plugin-collector-cpu-ec2-periodic/)"
 ci:
   - https://travis-ci.org/intelsdi-x/snap-plugin-collector-cpu
+  - https://ci.snap-telemetry.io/job/snap-plugin-collector-cpu-ec2-periodic


### PR DESCRIPTION
This will allow for [plugin sync](https://github.com/intelsdi-x/snap-pluginsync) to add a build status to the plugin catalog similar to what was done manually in https://github.com/intelsdi-x/snap/commit/05da8279b74647a63249da79437c6c0cce4e2e3d