### PR TITLE
Remove legacy check and change mocking behaviour

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -120,13 +120,13 @@ type CPUCollector struct {
 	snapMetricsNames     []string
 }
 
-// cpuInfo source of data for metrics
-var cpuInfo = "/proc/stat"
+// defaultProcPath source of data for metrics
+var defaultProcPath = "/proc"
 
 // New creates instance of interface info plugin
 func New() *CPUCollector {
 	return &CPUCollector{
-		proc_path: cpuInfo,
+		proc_path: defaultProcPath + "/stat",
 	}
 }
 
@@ -134,7 +134,7 @@ func New() *CPUCollector {
 // It returns error in case retrieval was not successful
 func (p *CPUCollector) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy := plugin.NewConfigPolicy()
-	policy.AddNewStringRule([]string{vendor, fs, Name}, "proc_path", false, plugin.SetDefaultString("/proc"))
+	policy.AddNewStringRule([]string{vendor, fs, Name}, "proc_path", false, plugin.SetDefaultString(defaultProcPath))
 
 	return *policy, nil
 }
@@ -238,13 +238,12 @@ func (p *CPUCollector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, err
 }
 
 func (p *CPUCollector) init(cfg plugin.Config) error {
-	if _, ok := cfg["proc_path"]; ok {
-		procPath, err := cfg.GetString("proc_path")
-		if err != nil {
-			procPath = "/proc"
-		}
+	procPath, err := cfg.GetString("proc_path")
+	if err == nil {
+		// change default if proc_path supplied
 		p.proc_path = procPath + "/stat"
 	}
+
 	fh, err := os.Open(p.proc_path)
 	if err != nil {
 		return err

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -34,7 +34,6 @@ import (
 
 type CPUInfoSuite struct {
 	suite.Suite
-	MockCPUInfo string
 }
 
 const (
@@ -53,10 +52,11 @@ const (
 	defaultFormatCpuStatIndex = 0
 	narrowFormatCpuStatIndex  = 7
 	eightColumnCpuStatIndex   = 8
+
+	mockPath = "MockCPUInfo"
 )
 
 func (cis *CPUInfoSuite) SetupSuite() {
-	cpuInfo = cis.MockCPUInfo
 	loadMockCPUInfo(0)
 }
 
@@ -65,17 +65,19 @@ func (cis *CPUInfoSuite) TearDownSuite() {
 }
 
 func removeMockCPUInfo() {
-	os.Remove(cpuInfo)
+	os.Remove(mockPath)
 }
 
 func TestGetStatsSuite(t *testing.T) {
-	suite.Run(t, &CPUInfoSuite{MockCPUInfo: "MockCPUInfo"})
+	suite.Run(t, &CPUInfoSuite{})
 }
 
 func mockNew() *CPUCollector {
 	p := New()
+	p.proc_path = mockPath
 	emptyCfg := plugin.Config{}
-	p.init(emptyCfg)
+	err := p.init(emptyCfg)
+	So(err, ShouldBeNil)
 	So(p, ShouldNotBeNil)
 	So(p.snapMetricsNames, ShouldNotBeNil)
 	return p
@@ -129,7 +131,7 @@ func loadMockCPUInfo(dataSetNumber int) {
 	}
 
 	cpuInfoContent := []byte(content)
-	f, err := os.Create(cpuInfo)
+	f, err := os.Create(mockPath)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR simplifies mocking, making it easier to maintain.